### PR TITLE
Add global apig-main service which creates API Gateway and can be used by all backend microservices

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# This file contains environment variables available to the docker-compose.yml file
+# Value needs double quote " if there is a comment after the value!
+
+AWS_DEFAULT_REGION="us-east-1"
+AWS_ENDPOINT_URL="http://localstack:4566"
+AWS_ACCESS_KEY_ID="fakecred"
+AWS_SECRET_ACCESS_KEY="fakecred"
+APIG_TAG_ID="API_TAG_ID"
+APIG_TAG="apig-main"
+APIG_STAGE="PROD"
+APIG_WAIT="300"

--- a/apig-main/README.md
+++ b/apig-main/README.md
@@ -1,0 +1,10 @@
+# apig-main
+
+This service provides the API Gateway used by all other backend microservices.  
+Its purpose is to deploy the API Gateway with the given configurations in config and the tag specified in docker-compose.  
+This allows all other microservices to find its API_ID and URL via the deploy_utils functions
+
+## Workflow
+apig-main creates the API, it does not deploy it.  
+To deploy an API, it must contain methods.  
+Hence, each microservice will update the API (adding resources, methods, integrations) and then deploys/redeploys it, always to the same stage.

--- a/apig-main/deploy_apig_main.py
+++ b/apig-main/deploy_apig_main.py
@@ -1,0 +1,46 @@
+"""
+Deploy one API Gateway service which is available to all other backend microservices
+Deploy no resources, only create the service and a deployment with a stage
+"""
+
+import os
+import boto3
+from pprint import PrettyPrinter
+pp = PrettyPrinter(indent=2)
+
+##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--
+# FOR MANUAL RUNING ONLY - DO NOT RUN IF IN A DOCKER CONTAINER
+IN_DOCKER = os.environ.get('AM_I_IN_A_DOCKER_CONTAINER', False)
+
+if not IN_DOCKER:
+    os.chdir("./apig-main")
+    # Also set all AWS env vars, point to running localstack container not in a docker-compose network
+    os.environ['AWS_DEFAULT_REGION']='us-east-1'
+    os.environ['AWS_ENDPOINT_URL']='https://localhost.localstack.cloud:4566' # For manual, use the default localstack url
+    os.environ['AWS_ACCESS_KEY_ID']='fakecred' # Sometimes boto3 needs credentials
+    os.environ['AWS_SECRET_ACCESS_KEY']='fakecred' # Sometimes boto3 needs credentials
+    os.environ['APIG_TAG'] = "apig-main"
+    os.environ['APIG_TAG_ID'] = "API_TAG_ID"
+    os.environ['APIG_STAGE'] = "PROD"
+# FOR MANUAL RUNING ONLY END
+##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--
+
+print("This is the environment")
+pp.pprint(dict(os.environ))
+
+APIG_NAME = os.environ['APIG_TAG']
+APIG_TAG_ID = os.environ['APIG_TAG_ID']
+
+# Create client
+apig_client = boto3.client("apigateway")
+
+###
+# API Gateway
+print("API Gateway create ...")
+
+apig_created = apig_client.create_rest_api(
+    name = APIG_NAME,
+    tags={APIG_TAG_ID:APIG_NAME}
+)
+
+print(f"API Gateway with id {apig_created['id']} created")

--- a/apig-main/dockerfile
+++ b/apig-main/dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-alpine
+
+WORKDIR /app
+COPY ./deploy_apig_main.py /app/
+COPY ./requirements.txt /app/
+
+# Install python dependencies
+RUN pip install -r requirements.txt
+
+# Make deploy script executable
+RUN chmod +x deploy_apig_main.py
+
+# This line runs the deploy script upon running the container
+CMD ["python", "deploy_apig_main.py"]

--- a/apig-main/requirements.txt
+++ b/apig-main/requirements.txt
@@ -1,0 +1,6 @@
+boto3
+awscli
+awscli-local
+pyperclip
+requests
+simplejson

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: "3"
 services:
 
-  frontend:
-    container_name: "frontend"
-    build: ./frontend
-    ports:
-      - "3000:3000"
-    #environment:
-    #  - REACT_APP_API_URL=http://localhost:4566
-    volumes:
-      - "./frontend/public:/app/public"
-      - "./frontend/src:/app/src"
+  # frontend:
+  #   container_name: "frontend"
+  #   build: ./frontend
+  #   ports:
+  #     - "3000:3000"
+  #   #environment:
+  #   #  - REACT_APP_API_URL=http://localhost:4566
+  #   volumes:
+  #     - "./frontend/public:/app/public"
+  #     - "./frontend/src:/app/src"
 
   localstack:
     container_name: "localstack"
@@ -26,12 +26,34 @@ services:
       - SKIP_SSL_CERT_DOWNLOAD=1
       - SKIP_INFRA_DOWNLOADS=1
       - DISABLE_EVENTS=1
-      - AWS-REGION=us-east-1
-      - AWS_ACCESS_KEY_ID=localstack
-      - AWS_SECRET_ACCESS_KEY=localstack
+      - AWS-REGION=${AWS_DEFAULT_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
     volumes:
       - ".volume:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - backend
+
+  apig-main:
+    container_name: "apig-main"
+    build:
+      context: ./apig-main
+      dockerfile: dockerfile
+      no_cache: true
+    environment:
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL} # host localstack must match the name of the service which runs localstack
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} # Sometimes boto3 needs credentials
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} # Sometimes boto3 needs credentials
+      - APIG_TAG_ID=${APIG_TAG_ID}
+      - APIG_TAG=${APIG_TAG}
+      - APIG_STAGE=${APIG_STAGE}
+      - AM_I_IN_A_DOCKER_CONTAINER=${AM_I_IN_A_DOCKER_CONTAINER:-True}
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    depends_on:
+      - localstack
     networks:
       - backend
   
@@ -42,18 +64,20 @@ services:
       dockerfile: dockerfile
       no_cache: true
     environment:
-      - AWS_DEFAULT_REGION=us-east-1
-      - AWS_ENDPOINT_URL=http://localstack:4566 # host localstack must match the name of the service which runs localstack
-      - AWS_ACCESS_KEY_ID=fakecred # Sometimes boto3 needs credentials
-      - AWS_SECRET_ACCESS_KEY=fakecred # Sometimes boto3 needs credentials
-      - APIG_TAG_ID=API_TAG_ID
-      - APIG_TAG=apig_template
-      - APIG_STAGE=PROD
-      - AM_I_IN_A_DOCKER_CONTAINER=True
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL} # host localstack must match the name of the service which runs localstack
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} # Sometimes boto3 needs credentials
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} # Sometimes boto3 needs credentials
+      - APIG_TAG_ID=${APIG_TAG_ID}
+      - APIG_TAG=${APIG_TAG}
+      - APIG_STAGE=${APIG_STAGE}
+      - AM_I_IN_A_DOCKER_CONTAINER=${AM_I_IN_A_DOCKER_CONTAINER:-True}
+      - APIG_WAIT=${APIG_WAIT}
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     depends_on:
       - localstack
+      - apig-main
     networks:
       - backend
   
@@ -64,15 +88,20 @@ services:
       dockerfile: dockerfile_debugger
       no_cache: true
     environment:
-      - AWS_DEFAULT_REGION=us-east-1
-      - AWS_ENDPOINT_URL=http://localstack:4566 # host localstack must match the name of the service which runs localstack
-      - AWS_ACCESS_KEY_ID=fakecred # Sometimes boto3 needs credentials
-      - AWS_SECRET_ACCESS_KEY=fakecred
-      - AM_I_IN_A_DOCKER_CONTAINER=True
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL} # host localstack must match the name of the service which runs localstack
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} # Sometimes boto3 needs credentials
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} # Sometimes boto3 needs credentials
+      - APIG_TAG_ID=${APIG_TAG_ID}
+      - APIG_TAG=${APIG_TAG}
+      - APIG_STAGE=${APIG_STAGE}
+      - AM_I_IN_A_DOCKER_CONTAINER=${AM_I_IN_A_DOCKER_CONTAINER:-True}
+      - APIG_WAIT=${APIG_WAIT}
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     depends_on:
       - localstack
+      - apig-main
     networks:
       - backend
 

--- a/template-microservice/README.md
+++ b/template-microservice/README.md
@@ -3,30 +3,36 @@
 A minimal example of a backend service setup. Consists of three components
 - Dynamo DB
 - Lambda functions
-- API Gateway
+- API Gateway integration
 
-NOTE: This example shows the creation and the deployment of the API Gateway amonst other. In the actual architecture, there will be one "global" API Gateway, and an actual microservice will only create resources, methods and integrations. For the sake of completion, the creation and deployment part of the code is included as well.  
+NOTE: The service does not CREATE the API Gateway. That is done by apig-main. Its a small service whose only task is to create an API Gateway to which this template and all backend services derived from it can deploy resources, methods and integrations.
 
-The workflow is: A [deploy script](deploy.py) which uses [deploy utilities](deploy_utils.py) is run, where all services are deployed. If successful, one Dynamo DB, multiple Lambda functions and an API Gateway will be deployed. To test the services, one can run the files in the test folder which list available resources deployed and make some example calls to the API Gateway.   
+The workflow is: A [deploy script](deploy.py) which uses [deploy utilities](deploy_utils.py) is run, where all services are deployed. If successful, one Dynamo DB, multiple Lambda functions and an API Gateway integration will be deployed. To test the services, one can run the files in the test folder which list available resources deployed and make some example calls to the API Gateway.   
 
 The service can be run in two ways: In a "debug" localstack container or in the realistic way thorugh [docker-compose](../docker-compose.yml).
 
 ## Debug through simple localstack container
 This way, the deploy script itself can be tested and be run line by line. The progress of the deployment can be tracked in the localstack UI through the browser (https://app.localstack.cloud/dashboard).
 - Needs a host machine with localstack installed.
-- Run `localstack start`. There should be a localstack-main container being started
+- Run `localstack start`. There should be a localstack-main container being started on the host.
+- Now you first create the API Gateway on localstack by running the [apig-main deploy script](../apig-main/deploy_apig_main.py)
 - Now you can run the [deploy script](deploy.py) line by line from the root directory, verifying on each step in the localstack UI if the services are deployed correctly. Additionally, you can check the logs of the localstack container.
-- The deploy script checks if it runs in a docker container or locally and sets the environment variables for the AWS/localstack services accordingly (it sets `https://localhost.localstack.cloud:4566` as the endpoint).
+- The deploy script checks if it runs in a docker container or locally and sets the environment variables for the AWS/localstack services accordingly (it sets by default `https://localhost.localstack.cloud:4566` as the endpoint).
 
 ## Run with docker-compose
 This is the simulation of the "real" service.
-- `docker compose up -d --build` to start the containers. The following services (frontend and other services ignored) are started:
+- `docker compose up -d --build` to start the containers from the host machine. The following services (frontend and other services ignored) are started:
     - localstack
+    - apig-main
     - template-microservice. This container runs upon creation the [deploy script](deploy.py) which sets up all the AWS services on the localstack container
     - template-microservice-debugger. Same as template-microservice, but keeps running. Can be used to `docker exec -it template-microservice-debugger /bin/sh` and test a curl on the deployed APIs which are available in the localstack container of the docker-compose network.
-- Wait (ca 30sec) until the template-microservice container exits, this means that the deployment is over (one can check the logs in the container, it should print some progress statements during the deployment).
-- Now you can test the deployed services with the scripts in the test folder. What you do is 1) copy the script from your host machine to the running debugger container and 2) execute the script. You will see the output in the console.
-- Each test script contains the linux command in the header of the file, it looks something like ``
+- First the apig-main container will exit. This means the API Gateway is created. You can check the container logs.
+- The template-microservice service does wait for the API to be created by default, maximum 5 minutes. It should not take longer than a few seconds though.
+- Wait so until the template-microservice container exits, this means that the deployment is over (one can check the logs in the container, it should print some progress statements during the deployment).
+- Now you can test the deployed services with the scripts in the test folder.
+- The script contains a line in the comment at the beginning of the file, looking like that: `docker cp template-microservice/test/test_apig.py template-microservice-debugger:/app && docker exec template-microservice-debugger /bin/sh -c "python test_apig.py"`
+    1. copy the script from your host machine to the running debugger container
+    2. execute the script. You will see the output in the console.
 
 ## The API endpoint
 The API endpoint that is deployed and will be reachable for other services like the frontend is constructed in the script [deploy utils](deploy_utils.py) method `find_api_id_by_tag` and `get_resource_path` and follows the pattern

--- a/template-microservice/deploy.py
+++ b/template-microservice/deploy.py
@@ -8,7 +8,7 @@ Deploy two lambda functions
 - get_lambda for listing all currently saved items in the DB or a specific one with a given {id} in the pathParameter
 - post_lambda for putting a new item to the DB
 
-Deploy an API Gateway which provides routes as specified in resources_to_create.json
+Update a API Gateway which provides routes as specified in resources_to_create.json
 - xxx/template-microservice GET
     Get all items in the dynamo DB via lambda get_lambda
     Lambda fct: get_lambda
@@ -22,7 +22,10 @@ Deploy an API Gateway which provides routes as specified in resources_to_create.
 
 import os
 import boto3
+import botocore
 import simplejson as json
+from datetime import datetime
+import time
 from pprint import PrettyPrinter
 pp = PrettyPrinter(indent=2)
 
@@ -37,9 +40,10 @@ if not IN_DOCKER:
     os.environ['AWS_ENDPOINT_URL']='https://localhost.localstack.cloud:4566' # For manual, use the default localstack url
     os.environ['AWS_ACCESS_KEY_ID']='fakecred' # Sometimes boto3 needs credentials
     os.environ['AWS_SECRET_ACCESS_KEY']='fakecred' # Sometimes boto3 needs credentials
-    os.environ['APIG_TAG'] = "apig_template"
+    os.environ['APIG_TAG'] = "apig-main"
     os.environ['APIG_TAG_ID'] = "API_TAG_ID"
     os.environ['APIG_STAGE'] = "PROD"
+    os.environ['APIG_WAIT'] = "300"
 # FOR MANUAL RUNING ONLY END
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--
 
@@ -94,7 +98,7 @@ def get_resources_to_create() -> dict:
     return res
 
 print("Environment:\n")
-pp.pprint(os.environ)
+pp.pprint(dict(os.environ))
 
 # Parameters
 db_schema = get_db_config()
@@ -102,12 +106,17 @@ request_models = get_request_models()
 request_validators = get_request_validators()
 resources_to_create = get_resources_to_create()
 
-LAMBDA_FUNCTIONS_TO_DEPLOY = ["get_lambda","post_lambda"] # TODO: Fetch names of all subdirs of lambdas/ instead of manually typing them out
+# Get all lambda functions which are found in the subfolders of the folder /lambdas
+print("Locate all lambda functions to deploy in folder /lambdas ...")
+LAMBDA_FUNCTIONS_TO_DEPLOY = [function_folder for function_folder in os.listdir("./lambdas") if os.path.isdir("./lambdas/" + function_folder)]
+print(f"Found lambda functions to deploy: {', '.join(LAMBDA_FUNCTIONS_TO_DEPLOY)}")
+
 LAMBDA_ROLE = "arn:aws:iam::000000000000:role/lambda-role" # given by localstack
 
 DYNAMO_DB_NAME = db_schema['TableName']
 APIG_NAME = os.environ['APIG_TAG']
 APIG_TAG_ID = os.environ['APIG_TAG_ID']
+APIG_WAIT = int(os.environ['APIG_WAIT'])
 
 # Create clients
 lambda_client = boto3.client("lambda")
@@ -115,46 +124,127 @@ dynamo_client = boto3.client("dynamodb")
 apig_client = boto3.client("apigateway")
 
 ###
+# First of all, fetch the api_id to work with. Wait for some time until the API service has started and created
+###
+# API Gateway deployment
+
+api_id = None
+
+print(f"Try to find API created by apig-main, waiting for max {APIG_WAIT} seconds ...")
+timestamp_start_finding_api_id = datetime.now()
+print(f"Trying to find api_id, start at {timestamp_start_finding_api_id}")
+while True:
+    try:
+        api_id = deploy_utils.find_api_id_by_tag(apig_client = apig_client, tag_key = APIG_TAG_ID, tag_value = APIG_NAME)
+        break
+    except ValueError as value_error:
+        tmp_timestamp = datetime.now()
+        print(f"Error trying to find api_id, current time {tmp_timestamp}, wait and try again ...")
+        time.sleep(5)
+        if (tmp_timestamp - timestamp_start_finding_api_id).seconds > APIG_WAIT:
+            print(f"Exceeded waiting time, stop trying to find the api")
+            break
+
+if not api_id:
+    raise ValueError(f"api_id for API with tag {APIG_TAG_ID} : {APIG_NAME} not found, abort")
+else:
+    print("api_id found")
+print(f"Use api_id {api_id}")
+
+
+###
 # Dynamo DB deployment  
 print("Dynamo DB deployment ...")
-dynamo_client.create_table(**db_schema)
-print("Dynamo DB created")
+try:
+    dynamo_client.create_table(**db_schema)
+except botocore.exceptions.ClientError as client_error:
+    if client_error.response['Error']['Code'] == "ResourceInUseException":
+        print(f"Dynamo DB {DYNAMO_DB_NAME} already exists, skip and use that one")
+        pass
+    else:
+        # If the error is not a conflict (already exists), raise the error
+        print(f"Dyanmo DB {DYNAMO_DB_NAME} some other error occured, abort")
+        print(client_error.response['message'])
+        raise client_error
+print("Dynamo DB created or already existing")
+
 
 ###
 # Lambda deployment
-print("Lambda deployment ...")
+print("Lambda deployment, pass if function already exists ...")
 lambdas = {}
+# Get all existing lambda functions
+try:
+    existing_lambdas = lambda_client.list_functions()['Functions']
+    existing_lambdas_names = [l['FunctionName'] for l in existing_lambdas]
+except KeyError as key_error:
+    print(f"No Functions found in list_functions, try to deploy lambdas anyways")
 for lambda_function_to_create in LAMBDA_FUNCTIONS_TO_DEPLOY:
+
+    # If lambda_function_to_create already exists, inform and skip
+    if lambda_function_to_create in existing_lambdas_names:
+        print(f"Lambda function {lambda_function_to_create} already exists, use that one and skip")
+        # Update the lambdas dict with the already existing lambda
+        existing_lambda_arn = existing_lambdas[existing_lambdas_names.index(lambda_function_to_create)]['FunctionArn']
+        lambdas[lambda_function_to_create] = existing_lambda_arn
+        continue
+
     lambdas[lambda_function_to_create] = deploy_utils.deploy_lambda(
         lambda_client = lambda_client,
         fct_name = lambda_function_to_create,
-        env = {"TableName" : DYNAMO_DB_NAME}
+        env = {"TableName" : DYNAMO_DB_NAME, "Role" : LAMBDA_ROLE}
     )
     print(f"Waiting over, function {lambda_function_to_create} is ready")
 print("Lambda deployment done")
 
+
 ###
 # API Gateway deployment
-print("API Gateway deployment ...")
-api_id = deploy_utils.create_api(
-    apig_client = apig_client,
-    api_name = APIG_NAME,
-    api_tag = APIG_NAME,
-    tag_id = APIG_TAG_ID
-)
+print("API Gateway ...")
 
-print(f"Create api request models ...")
+###
+# Request Models
+print(f"Create api request models, pass if model already exists ...")
 for model_name, model in request_models.items():
-    apig_client.create_model(
-        restApiId = api_id,
-        name = model_name,
-        schema = json.dumps(model['model_spec']),
-        contentType = model['contentType']        
-    )
+    try:
+        apig_client.create_model(
+            restApiId = api_id,
+            name = model_name,
+            schema = json.dumps(model['model_spec']),
+            contentType = model['contentType']        
+        )
+    except botocore.exceptions.ClientError as client_error:
+        if client_error.response['Error']['Code'] == "ConflictException":
+            print(f"Model {model_name} already exists, skip")
+            pass
+        else:
+            # If the error is not a conflict (already exists), raise the error
+            print(f"Model {model_name} some other error occured, abort")
+            print(client_error.response['message'])
+            raise client_error
 
-print("Create api request validators ...")
+###
+# Request Validators
+print("Create api request validators, pass if validator name already exists ...")
+# Get all existing validators
+try:
+    existing_validators = apig_client.get_request_validators(restApiId = api_id)['items']
+    existing_validators_names = [validator['name'] for validator in existing_validators]
+except KeyError as key_error:
+    print(f"No items found in get_request_validators, try to deploy validators anyways")
+
 api_validators = {}
 for validator_name, validator in request_validators.items():
+    
+    # If validator_name already exists, inform and skip
+    if validator_name in existing_validators_names:
+        print(f"Validator {validator_name} already exists, use that one and skip")
+        # Update the api_validators dict with the already existing validator
+        existing_validator_id = existing_validators[existing_validators_names.index(validator_name)]['id']
+        api_validators[validator_name] = existing_validator_id
+        continue
+
+    # Create validator
     validator = apig_client.create_request_validator(
         restApiId = api_id,
         name = validator_name,
@@ -163,6 +253,8 @@ for validator_name, validator in request_validators.items():
     )
     api_validators[validator_name] = validator['id']
 
+###
+# Methods and Integrations
 print("Create method and integration ...")
 for resource_type, resource_list in resources_to_create.items():
     print(f"create {resource_type} ... ")
@@ -205,12 +297,14 @@ for resource_type, resource_list in resources_to_create.items():
                 requestValidatorId = api_validators['bodyOnly'] # The default bodyOnly validator
             )
 
+###
+# Deployment
 print("Create api deployment ...")
 deploy_utils.deploy_api(
     apig_client = apig_client,
     api_id = api_id,
     stage_name = os.environ['APIG_STAGE']
 )
-print("API Gateway deployment done")
+print("API Gateway deployment update done")
 
-print("Deployment done")
+print("API Gateway done")

--- a/template-microservice/test/test_apig.py
+++ b/template-microservice/test/test_apig.py
@@ -24,10 +24,11 @@ if not IN_DOCKER:
     os.environ['AWS_ENDPOINT_URL']='https://localhost.localstack.cloud:4566' # For manual, use the default localstack url
     os.environ['AWS_ACCESS_KEY_ID']='fakecred' # Sometimes boto3 needs credentials
     os.environ['AWS_SECRET_ACCESS_KEY']='fakecred' # Sometimes boto3 needs credentials
-    os.environ['APIG_TAG'] = "apig_template"
+    os.environ['APIG_TAG'] = "apig-main"
     os.environ['APIG_TAG_ID'] = "API_TAG_ID"
     os.environ['APIG_STAGE'] = "PROD"
     os.environ['PROTOCOL'] = "https"
+    os.environ['APIG_WAIT'] = "300"
 # FOR MANUAL RUNING ONLY END
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--
 
@@ -37,9 +38,9 @@ import deploy_utils
 lambda_client = boto3.client("lambda")
 apig_client = boto3.client("apigateway")
 
-api_stage_name = "PROD"
-api_tag_id = "API_TAG_ID"
-api_id_to_seach = "apig_template"
+api_stage_name = os.environ['APIG_STAGE']
+api_tag_id = os.environ['APIG_TAG_ID']
+api_id_to_seach = os.environ['APIG_TAG']
 
 api_id = deploy_utils.find_api_id_by_tag(
     apig_client,


### PR DESCRIPTION
- Add .env file for docker-compose
- Remove create_api from template-microservice, this is now done by apig-main
- Add waiting for api deployment in template-microservice, so that api gateway is ready for deployment of template-microservice
- Add checks for existing dynamodb, lambdas, request validators, request models